### PR TITLE
Use `abi3` wheels to support arbitrary Python versions

### DIFF
--- a/.github/workflows/create_wheels.yaml
+++ b/.github/workflows/create_wheels.yaml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [37, 38, 39, 310, 311]
 
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +33,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
         env:
-          CIBW_BUILD: cp${{matrix.python-version}}-*
+          CIBW_BUILD: cp38-*
           CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH" CARGO_TERM_COLOR="always"'
           CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
 
@@ -49,7 +48,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
@@ -59,10 +57,10 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: wheels
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.x
     - name: Install wheel
       run: |
         pip install --force-reinstall --no-deps --no-index --find-links . cpp-demangle
@@ -86,7 +84,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.x
       - name: Push to PyPi
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/create_wheels.yaml
+++ b/.github/workflows/create_wheels.yaml
@@ -31,7 +31,7 @@ jobs:
           toolchain: stable
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.3
+        uses: pypa/cibuildwheel@v3.0.0
         env:
           CIBW_BUILD: cp38-*
           CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH" CARGO_TERM_COLOR="always"'

--- a/.github/workflows/create_wheels.yaml
+++ b/.github/workflows/create_wheels.yaml
@@ -25,11 +25,6 @@ jobs:
         with:
           platforms: all
 
-      - name: Setup rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.0.0
         env:

--- a/.github/workflows/create_wheels.yaml
+++ b/.github/workflows/create_wheels.yaml
@@ -58,7 +58,7 @@ jobs:
       with:
         name: wheels-${{ matrix.os }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Install wheel
@@ -83,7 +83,7 @@ jobs:
         env:
           GHR_PATH: .
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Push to PyPi

--- a/.github/workflows/create_wheels.yaml
+++ b/.github/workflows/create_wheels.yaml
@@ -17,7 +17,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -51,7 +51,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: py_cpp_demangle_source
     - uses: actions/download-artifact@v4

--- a/.github/workflows/create_wheels.yaml
+++ b/.github/workflows/create_wheels.yaml
@@ -38,9 +38,9 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
 
       - name: Upload Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.os }}
           path: wheelhouse
 
   test-wheels:
@@ -54,9 +54,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         path: py_cpp_demangle_source
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.os }}
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -74,9 +74,10 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [test-wheels]
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
+          merge-multiple: true
       - name: Create GitHub Release
         uses: fnkr/github-action-ghr@v1.3
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ cpp_demangle = "0.4.0"
 
 [dependencies.pyo3]
 version = "0.17.3"
-features = ["extension-module"]
+features = ["extension-module", "abi3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,6 @@
 test-command = ""
 skip = ["pp*", "*musl*",  "*-manylinux_i686", "*win32"]
 
-[tool.cibuildwheel.macos]
-archs = ["x86_64"]
-
 [tool.cibuildwheel.macos.environment]
 MACOSX_DEPLOYMENT_TARGET = "10.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # skip testing in the cibuildwheel phase, will install the wheels later
 # and verify
 test-command = ""
-skip = ["pp*", "*musl*",  "*-manylinux_i686", "*win32"]
+skip = ["*musl*",  "*-manylinux_i686", "*win32"]
 
 [tool.cibuildwheel.macos.environment]
 MACOSX_DEPLOYMENT_TARGET = "10.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ skip = ["pp*", "*musl*",  "*-manylinux_i686", "*win32"]
 [tool.cibuildwheel.macos]
 archs = ["x86_64"]
 
+[tool.cibuildwheel.macos.environment]
+MACOSX_DEPLOYMENT_TARGET = "10.12"
+
 [build-system]
 requires = [
     "setuptools>=42",

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ search = name = "py_cpp_demangle"
 	version = "{current_version}"
 replace = name = "py_cpp_demangle"
 	version = "{new_version}"
+
+[bdist_wheel]
+py_limited_api=cp38


### PR DESCRIPTION
As this package does not use any special part of the CPython interface, it can leverage the [stable abi](https://docs.python.org/3/c-api/stable.html#stable-abi), not needing version specific wheels.

This supersedes #11. I also needed to update the github actions to make them work again, so this PR also makes #14 obsolete. 